### PR TITLE
fix the PreferenceTheme text color

### DIFF
--- a/app/src/main/java/com/andromeda/ara/MainActivity.java
+++ b/app/src/main/java/com/andromeda/ara/MainActivity.java
@@ -469,7 +469,7 @@ public class MainActivity extends AppCompatActivity {
 
     }
 
-    public void yourMethodName(MenuItem menuItem) {
+    public void openSettingsActivity(MenuItem menuItem) {
         startActivity(new Intent(this, com.andromeda.ara.SettingsActivity.class));
     }
 

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -20,7 +20,7 @@
     tools:context="com.andromeda.ara.MainActivity">
     <item
         android:id="@+id/action_settings"
-        android:onClick="yourMethodName"
+        android:onClick="openSettingsActivity"
         android:orderInCategory="100"
         android:title="@string/action_settings"
         app:showAsAction="never" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -43,7 +43,7 @@
 
     <style name="PreferencesTheme" parent="AppTheme.NoActionBar">
         <item name="android:windowBackground">@drawable/settingsback</item>
-        <item name="android:textColor">@color/md_white_1000</item>
+        <item name="android:textColorPrimary">@color/md_white_1000</item>
         <item name="android:textColorSecondary">@color/md_white_1000</item>
     </style>
     <style name="AppTheme.Translucent" parent="AppTheme.NoActionBar">


### PR DESCRIPTION
Hello I made a simple change on the settings page. The text color was didn't work, and now it is shown as per App Theme. I made screen shoot before and after the adjustment for clearer picture for you.

I have also made change on the one of the method name on MainActivity. Just to add clarity for whoever read the code.
![Webp net-resizeimage](https://user-images.githubusercontent.com/15926749/66043668-d5393d80-e530-11e9-84ba-f61c0e7aff40.png)
![Webp net-resizeimage (1)](https://user-images.githubusercontent.com/15926749/66043677-dc604b80-e530-11e9-8f94-acb479688f09.png)